### PR TITLE
fix np.array type to float64

### DIFF
--- a/data_model.py
+++ b/data_model.py
@@ -31,7 +31,7 @@ class StockDataSet(object):
         else:
             self.raw_seq = [price for tup in raw_df[['Open', 'Close']].values for price in tup]
 
-        self.raw_seq = np.array(self.raw_seq)
+        self.raw_seq = np.array(self.raw_seq, dtype=np.float64)
         self.train_X, self.train_y, self.test_X, self.test_y = self._prepare_data(self.raw_seq)
 
     def info(self):


### PR DESCRIPTION
some financial instruments have integer price.
if you try to normalize this seq, you got -1, 0, +1 
to fix it you have to add dtype=np.float64, when you are creating np.array (line 34)